### PR TITLE
Fix analytics controller responses and tighten CSP

### DIFF
--- a/backend/java-services/src/main/java/org/houstonoilairs/analytics/AIResearchAnalyzer.java
+++ b/backend/java-services/src/main/java/org/houstonoilairs/analytics/AIResearchAnalyzer.java
@@ -10,8 +10,6 @@ import java.time.temporal.ChronoUnit;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.MediaType;
-import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -327,36 +325,45 @@ class AnalyticsController {
     }
 
     @GetMapping(value = "/research-trends", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CompletableFuture<List<AIResearchAnalyzer.ResearchMetric>> getResearchTrends(
+    public CompletableFuture<org.springframework.http.ResponseEntity<List<AIResearchAnalyzer.ResearchMetric>>> getResearchTrends(
             @RequestParam String category,
             @RequestParam(defaultValue = "24") int timeframe) {
         return analyzer.analyzeResearchTrends(category, timeframe).thenApply(metrics -> {
             logger.info("Research trends response: {}", metrics);
             if (metrics.isEmpty()) {
-                return Collections.emptyList(); // Return empty list instead of throwing NO_CONTENT
+                return org.springframework.http.ResponseEntity.noContent().build();
             }
-            return metrics;
+            return org.springframework.http.ResponseEntity
+                    .ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(metrics);
         });
     }
 
     @PostMapping(value = "/network-analysis", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CompletableFuture<AIResearchAnalyzer.NetworkAnalysis> performNetworkAnalysis(
+    public CompletableFuture<org.springframework.http.ResponseEntity<AIResearchAnalyzer.NetworkAnalysis>> performNetworkAnalysis(
             @RequestBody List<String> categories) {
         return analyzer.performNetworkAnalysis(categories).thenApply(analysis -> {
             logger.info("Network analysis response: {}", analysis);
             if (analysis.getNodes().isEmpty() || analysis.getEdges().isEmpty()) {
-                return new AIResearchAnalyzer.NetworkAnalysis(); // Return empty analysis instead of throwing NO_CONTENT
+                return org.springframework.http.ResponseEntity.noContent().build();
             }
-            return analysis;
+            return org.springframework.http.ResponseEntity
+                    .ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(analysis);
         });
     }
 
     @GetMapping(value = "/health", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Map<String, Object> healthCheck() {
+    public org.springframework.http.ResponseEntity<Map<String, Object>> healthCheck() {
         Map<String, Object> status = new HashMap<>();
         status.put("status", "healthy");
         status.put("timestamp", Instant.now());
         status.put("service", "AI Research Analytics");
-        return status;
+        return org.springframework.http.ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(status);
     }
 }

--- a/backend/java-services/src/test/java/org/houstonoilairs/analytics/AnalyticsControllerTest.java
+++ b/backend/java-services/src/test/java/org/houstonoilairs/analytics/AnalyticsControllerTest.java
@@ -38,11 +38,29 @@ public class AnalyticsControllerTest {
     }
 
     @Test
+    public void testNetworkAnalysisEndpointNoContent() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/analytics/network-analysis")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[]"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
     public void testHealthEndpoint() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/analytics/health")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("healthy"));
+    }
+
+    @Test
+    public void testResearchTrendsEndpointNoContent() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/analytics/research-trends")
+                .param("category", "alignment")
+                .param("timeframe", "0")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/node-server/src/server.js
+++ b/backend/node-server/src/server.js
@@ -46,8 +46,8 @@ class HighPerformanceWebServer {
             contentSecurityPolicy: {
                 directives: {
                     defaultSrc: ["'self'"],
-                    scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-                    styleSrc: ["'self'", "'unsafe-inline'"],
+                    scriptSrc: ["'self'"],
+                    styleSrc: ["'self'", "https:"],
                     imgSrc: ["'self'", "data:", "https:"],
                     connectSrc: ["'self'", "ws:", "wss:"]
                 }


### PR DESCRIPTION
## Summary
- ensure analytics endpoints send JSON Content-Type and return 204 when no data
- add tests for no-content scenarios
- harden node server CSP by removing unsafe inline/eval directives

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*
- `npm test` *(fails: Could not read package.json)*
- `node --check src/server.js`

------
https://chatgpt.com/codex/tasks/task_b_68ab11ec904c83308dd661c0bdfc0742