### PR TITLE
Upgrade Spring stack to Spring Boot 3.3.4

### DIFF
--- a/REALITY_CHECKLIST.txt
+++ b/REALITY_CHECKLIST.txt
@@ -1,0 +1,4 @@
+- [ ] F1 Build java-services with Maven (`mvn clean package`) — UNVERIFIED (needs Maven Central access to resolve spring-boot-starter-parent 3.3.4).
+- [ ] F2 GET /api/analytics/research-trends — UNVERIFIED (service jar missing because Maven build failed offline).
+- [ ] F3 POST /api/analytics/network-analysis — UNVERIFIED (service jar missing because Maven build failed offline).
+- [ ] F4 GET /api/analytics/health — UNVERIFIED (service jar missing because Maven build failed offline).

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,21 +1,20 @@
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
-FROM openjdk:11-jre-slim AS java-builder
+FROM maven:3.9.6-eclipse-temurin-17 AS java-builder
 WORKDIR /app
 COPY java-services/pom.xml ./
 COPY java-services/src ./src
-RUN apt-get update && apt-get install -y maven
-RUN mvn clean package -DskipTests
+RUN mvn -B -DskipTests clean package
 
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app
 
 # Install Java runtime for multi-service support
-RUN apk add --no-cache openjdk11-jre
+RUN apk add --no-cache openjdk17-jre-headless
 
 # Copy Node.js dependencies
 COPY --from=base /app/node_modules ./node_modules

--- a/backend/java-services/pom.xml
+++ b/backend/java-services/pom.xml
@@ -1,38 +1,45 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.4</version>
+        <relativePath />
+    </parent>
+
     <groupId>org.houstonoilairs</groupId>
     <artifactId>java-services</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
+    <version>1.0.0</version>
     <name>java-services</name>
     <description>Java services for Houston Oil Airs</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <version>2.7.18</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.7.18</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.7.18</version>
-            <scope>test</scope>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -41,12 +48,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.7.18</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
+set -e
 
-# Start Java service in background
 java -jar java-services/*.jar &
+JAVA_PID=$!
 
-# Start Node.js service
-cd node-server && node src/server.js
+cleanup() {
+  kill "$JAVA_PID" 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+cd node-server
+exec node src/server.js
+

--- a/evidence/mvn_clean_package_offline.txt
+++ b/evidence/mvn_clean_package_offline.txt
@@ -1,0 +1,16 @@
+2025-09-19T08:46:26Z mvn -o clean package
+[INFO] Scanning for projects...
+[ERROR] [ERROR] Some problems were encountered while processing the POMs:
+[FATAL] Non-resolvable parent POM for org.houstonoilairs:java-services:1.0.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 (absent): Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 has not been downloaded from it before. and 'parent.relativePath' points at no local POM @ line 5, column 13
+ @
+[ERROR] The build could not read 1 project -> [Help 1]
+[ERROR]
+[ERROR]   The project org.houstonoilairs:java-services:1.0.0 (/workspace/Houston-Oil-Airs/backend/java-services/pom.xml) has 1 error
+[ERROR]     Non-resolvable parent POM for org.houstonoilairs:java-services:1.0.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 (absent): Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 has not been downloaded from it before. and 'parent.relativePath' points at no local POM @ line 5, column 13 -> [Help 2]
+[ERROR]
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR]
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
+[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException

--- a/features.json
+++ b/features.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "F1",
+    "feature": "Build java-services with Maven",
+    "command": "cd backend/java-services && mvn clean package",
+    "expected_signal": "Build logs end with 'BUILD SUCCESS' and a runnable jar appears under target/."
+  },
+  {
+    "id": "F2",
+    "feature": "GET /api/analytics/research-trends returns recent metrics",
+    "command": "curl -sS -D - http://localhost:8080/api/analytics/research-trends?category=test&timeframe=24",
+    "expected_signal": "HTTP 200 with application/json header and a non-empty JSON array payload."
+  },
+  {
+    "id": "F3",
+    "feature": "POST /api/analytics/network-analysis computes network graph",
+    "command": "curl -sS -D - -H 'Content-Type: application/json' -d '[\"ai\",\"ml\"]' http://localhost:8080/api/analytics/network-analysis",
+    "expected_signal": "HTTP 200 with application/json header and a JSON body containing 'nodes' and 'edges'."
+  },
+  {
+    "id": "F4",
+    "feature": "GET /api/analytics/health reports service status",
+    "command": "curl -sS -D - http://localhost:8080/api/analytics/health",
+    "expected_signal": "HTTP 200 with JSON body containing 'status':'healthy'."
+  }
+]

--- a/fixes/dependency-upgrades.patch
+++ b/fixes/dependency-upgrades.patch
@@ -1,0 +1,138 @@
+diff --git a/backend/Dockerfile b/backend/Dockerfile
+index 8c51015..40bece7 100644
+--- a/backend/Dockerfile
++++ b/backend/Dockerfile
+@@ -1,21 +1,20 @@
+-FROM node:18-alpine AS base
++FROM node:20-alpine AS base
+ 
+ WORKDIR /app
+ COPY package*.json ./
+-RUN npm ci --only=production
++RUN npm ci --omit=dev
+ 
+-FROM openjdk:11-jre-slim AS java-builder
++FROM maven:3.9.6-eclipse-temurin-17 AS java-builder
+ WORKDIR /app
+ COPY java-services/pom.xml ./
+ COPY java-services/src ./src
+-RUN apt-get update && apt-get install -y maven
+-RUN mvn clean package -DskipTests
++RUN mvn -B -DskipTests clean package
+ 
+-FROM node:18-alpine
++FROM node:20-alpine
+ WORKDIR /app
+ 
+ # Install Java runtime for multi-service support
+-RUN apk add --no-cache openjdk11-jre
++RUN apk add --no-cache openjdk17-jre-headless
+ 
+ # Copy Node.js dependencies
+ COPY --from=base /app/node_modules ./node_modules
+@@ -29,4 +28,4 @@ COPY start.sh ./
+ RUN chmod +x start.sh
+ 
+ EXPOSE 3001 8080
+-CMD ["./start.sh"]
+\ No newline at end of file
++CMD ["./start.sh"]
+diff --git a/backend/java-services/pom.xml b/backend/java-services/pom.xml
+index e8a0910..618ed42 100644
+--- a/backend/java-services/pom.xml
++++ b/backend/java-services/pom.xml
+@@ -1,38 +1,45 @@
+-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
++<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
++    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+     <modelVersion>4.0.0</modelVersion>
++
++    <parent>
++        <groupId>org.springframework.boot</groupId>
++        <artifactId>spring-boot-starter-parent</artifactId>
++        <version>3.3.4</version>
++        <relativePath />
++    </parent>
++
+     <groupId>org.houstonoilairs</groupId>
+     <artifactId>java-services</artifactId>
+-    <version>1.0-SNAPSHOT</version>
+-    <packaging>jar</packaging>
+-
++    <version>1.0.0</version>
+     <name>java-services</name>
+     <description>Java services for Houston Oil Airs</description>
+ 
+     <properties>
+-        <java.version>11</java.version>
++        <java.version>17</java.version>
+     </properties>
+ 
+     <dependencies>
+         <dependency>
+             <groupId>org.springframework.boot</groupId>
+-            <artifactId>spring-boot-starter</artifactId>
+-            <version>2.7.18</version>
++            <artifactId>spring-boot-starter-web</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>org.springframework.boot</groupId>
+-            <artifactId>spring-boot-starter-web</artifactId>
+-            <version>2.7.18</version>
++            <artifactId>spring-boot-starter-actuator</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>org.springframework.boot</groupId>
+-            <artifactId>spring-boot-starter-test</artifactId>
+-            <version>2.7.18</version>
+-            <scope>test</scope>
++            <artifactId>spring-boot-starter-validation</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>org.slf4j</groupId>
+             <artifactId>slf4j-api</artifactId>
+-            <version>1.7.36</version>
++        </dependency>
++        <dependency>
++            <groupId>org.springframework.boot</groupId>
++            <artifactId>spring-boot-starter-test</artifactId>
++            <scope>test</scope>
+         </dependency>
+     </dependencies>
+ 
+@@ -41,12 +48,6 @@
+             <plugin>
+                 <groupId>org.springframework.boot</groupId>
+                 <artifactId>spring-boot-maven-plugin</artifactId>
+-                <version>2.7.18</version>
+-            </plugin>
+-            <plugin>
+-                <groupId>org.apache.maven.plugins</groupId>
+-                <artifactId>maven-resources-plugin</artifactId>
+-                <version>3.3.0</version>
+             </plugin>
+         </plugins>
+     </build>
+diff --git a/backend/start.sh b/backend/start.sh
+index 9ac5fbe..58bc32e 100644
+--- a/backend/start.sh
++++ b/backend/start.sh
+@@ -1,7 +1,14 @@
+ #!/bin/sh
++set -e
+ 
+-# Start Java service in background
+ java -jar java-services/*.jar &
++JAVA_PID=$!
++
++cleanup() {
++  kill "$JAVA_PID" 2>/dev/null || true
++}
++trap cleanup INT TERM
++
++cd node-server
++exec node src/server.js
+ 
+-# Start Node.js service
+-cd node-server && node src/server.js
+\ No newline at end of file

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,0 +1,1 @@
+aae4d9686f26bf50f3f584981f6e3028551ca99bb2593a67d36cd8bdfd682c0c  evidence/mvn_clean_package_offline.txt


### PR DESCRIPTION
## Summary
- upgrade the java-services module to Spring Boot 3.3.4, Java 17, and current starters to address the reported vulnerabilities
- refresh the backend build pipeline by moving Docker builds to Node 20 and Maven Temurin 17 images and harden the startup script lifecycle handling
- add REALITY_CHECKLIST, features.json, evidence, sha256sums, and fixes patch artifacts documenting the verification state

## Testing
- `mvn -o clean package` *(fails: requires Maven Central access for org.springframework.boot:spring-boot-starter-parent:3.3.4)*

------
https://chatgpt.com/codex/tasks/task_b_68cd16b892a48320ba125116894768bd