### PR TITLE
Add Notion research board embed to landing page

### DIFF
--- a/REALITY_CHECKLIST.txt
+++ b/REALITY_CHECKLIST.txt
@@ -66,6 +66,7 @@
 - [x] Socket.IO client (VERIFIED - dependency in package.json)
 - [x] Vite build system (VERIFIED - vite.config.js configured)
 - [x] Legacy browser support (VERIFIED - @vitejs/plugin-legacy configured)
+- [x] Notion research board embed (VERIFIED - grep -n 'opalescent-physician' index.html)
 - [ ] UI functionality (UNVERIFIED - requires manual testing)
 
 ### Java Analytics Features

--- a/evidence/notion_embed_grep.txt
+++ b/evidence/notion_embed_grep.txt
@@ -1,0 +1,1 @@
+357:        <iframe src="https://opalescent-physician-f6e.notion.site/ebd/14778698e58e80398c4ff23c48a85b2c?v=27178698e58e802591a2000c0beec0a4" width="100%" height="600" frameborder="0" allowfullscreen></iframe>

--- a/features.json
+++ b/features.json
@@ -161,13 +161,22 @@
       "expected": "No import errors",
       "status": "UNVERIFIED",
       "evidence": null
+    },
+    {
+      "id": "F24",
+      "component": "Frontend",
+      "feature": "Notion Research Board Embed",
+      "command": "grep -n 'opalescent-physician' index.html",
+      "expected": "Iframe embed present in landing page",
+      "status": "VERIFIED",
+      "evidence": "evidence/notion_embed_grep.txt"
     }
   ],
   "summary": {
-    "total_features": 18,
-    "verified": 5,
+    "total_features": 19,
+    "verified": 6,
     "unverified": 13,
-    "success_rate": "27.8%"
+    "success_rate": "31.6%"
   },
   "blockers": [
     "Maven not installed (required for Java services)",

--- a/index.html
+++ b/index.html
@@ -129,6 +129,8 @@ main{position:relative;z-index:2}
 .widget-title{font-family:'Space Grotesk',sans-serif;font-size:1.5rem;font-weight:500;margin-bottom:20px;border-bottom:1px solid var(--border-color);padding-bottom:15px;color:var(--clay-darker)}
 .section-title{text-align:center;font-family:'Space Grotesk',sans-serif;font-size:3rem;margin-bottom:60px;background:rgba(239,220,213,.7);backdrop-filter:blur(15px);border:1px solid rgba(188,170,164,.5);border-radius:20px;padding:20px 40px;display:inline-block;box-shadow:inset 0 2px 4px rgba(255,255,255,.7),inset 0 -2px 4px rgba(188,170,164,.4),0 5px 10px rgba(93,64,55,.15);position:relative;left:50%;transform:translateX(-50%);color:var(--clay-darker)}
 .text-content{max-width:800px;margin:0 auto 60px;text-align:center;font-size:1.1rem;line-height:1.7;color:var(--text-secondary);background:rgba(239,220,213,.7);backdrop-filter:blur(15px);border:1px solid rgba(188,170,164,.5);border-radius:25px;padding:40px;box-shadow:inset 0 2px 4px rgba(255,255,255,.7),inset 0 -2px 4px rgba(188,170,164,.4),0 5px 10px rgba(93,64,55,.15)}
+.notion-embed-container{max-width:1200px;margin:0 auto 40px;background:rgba(239,220,213,.7);backdrop-filter:blur(12px);border:1px solid rgba(188,170,164,.5);border-radius:20px;box-shadow:inset 0 2px 4px rgba(255,255,255,.7),inset 0 -2px 4px rgba(188,170,164,.4),0 5px 10px rgba(93,64,55,.15);overflow:hidden}
+.notion-embed-container iframe{width:100%;height:600px;border:0;display:block}
 
 /* dashboard */
 .dashboard-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px}
@@ -340,6 +342,19 @@ main{position:relative;z-index:2}
         <div class="widget cta-card"><h3>Researchers</h3><p>Access cutting-edge visualization tools and collaborate on groundbreaking AI research projects.</p><a href="mailto:DouglasMitchell@HoustonOilAirs.org?subject=Research%20Collaboration%20Inquiry" class="cta-button email-button">Start Research<div class="email-tooltip">DouglasMitchell@HoustonOilAirs.org</div></a></div>
         <div class="widget cta-card"><h3>Developers</h3><p>Contribute to our open-source platform and help build the future of AI research tools.</p><a href="mailto:DouglasMitchell@HoustonOilAirs.org?subject=Development%20Contribution%20Interest" class="cta-button email-button">Contribute Code<div class="email-tooltip">DouglasMitchell@HoustonOilAirs.org</div></a></div>
         <div class="widget cta-card"><h3>Institutions</h3><p>Deploy our enterprise-ready platform in your organization and accelerate your research capabilities.</p><a href="mailto:DouglasMitchell@HoustonOilAirs.org?subject=Enterprise%20Deployment%20Inquiry" class="cta-button email-button">Deploy Platform<div class="email-tooltip">DouglasMitchell@HoustonOilAirs.org</div></a></div>
+    </div>
+</section>
+
+<!-- RESEARCH BOARD EMBED -->
+<section id="research-board" class="section">
+    <h2 class="section-title">Live Research Board</h2>
+    <p class="text-content">
+        Explore the latest updates from our collaborative workspace. This embedded Notion board provides a real-time window into
+        our environmental justice research pipeline, showcasing documents, datasets, and ongoing initiatives maintained by the
+        Houston Oil Airs team.
+    </p>
+    <div class="notion-embed-container">
+        <iframe src="https://opalescent-physician-f6e.notion.site/ebd/14778698e58e80398c4ff23c48a85b2c?v=27178698e58e802591a2000c0beec0a4" width="100%" height="600" frameborder="0" allowfullscreen></iframe>
     </div>
 </section>
 

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -2,3 +2,4 @@ ea20014dd1adb52c31c5a2c731acd3efc61ba4a4ec123aa6385b1f36e6222959  /home/donovan/
 aea59e532bae98fafdf5a847094b4ec9385db4f712158b3c1a7ffd5a317582dc  /home/donovan/Houston-Oil-Airs/evidence/maven_missing.txt
 1376b1202681e216effd066a67ec93ee3ea256d5bad0f1063e86a3d628979377  /home/donovan/Houston-Oil-Airs/evidence/threejs_integration_test.txt
 1914157121bc767a81e531a24ed0fb9cba7f60e241c8f7c9ad4678ec2b20c2f9  /home/donovan/Houston-Oil-Airs/evidence/visualization_api_test.txt
+6b892d189a6086c54a016c7af4d883984cc6d1ceb1fb1b93a3fb6f950a3b0b72  evidence/notion_embed_grep.txt

--- a/verification_matrix.md
+++ b/verification_matrix.md
@@ -18,6 +18,7 @@
 |----|---------|---------|-----------------|---------|---------------|
 | F8 | Vite Build Process | `cd frontend && npm run build` | Successful build | ✅ VERIFIED | Build succeeded in 5.66s |
 | F10 | Three.js Integration | `grep -r 'import.*three' frontend/src/` | Three.js imports found | ✅ VERIFIED | evidence/threejs_integration_test.txt |
+| F24 | Notion Research Board Embed | `grep -n 'opalescent-physician' index.html` | Iframe embed present | ✅ VERIFIED | evidence/notion_embed_grep.txt |
 | F9 | Development Server | `cd frontend && npm run dev` | Server starts on port 3000 | ❌ UNVERIFIED | Not tested |
 
 ### Node.js Backend API Server


### PR DESCRIPTION
## Summary
- embed the Houston Oil Airs Notion research board at the bottom of the landing page with polished styling
- add supporting CSS plus documentation updates to the reality checklist and verification matrix
- record new feature verification in features.json with captured evidence and updated hashes

## Testing
- `grep -n "opalescent-physician" index.html`

------
https://chatgpt.com/codex/tasks/task_b_68cee8fcf8908320aee897c14f613260